### PR TITLE
Use a data attribute to target the draggable elements

### DIFF
--- a/js/homepage.js
+++ b/js/homepage.js
@@ -42,10 +42,13 @@
     return onHashChange;
   })();
 
+  if (!document.querySelectorAll) {
+    return;
+  }
+
   // Show the bookmarklet hint when dragging.
-  var draggable = document.querySelectorAll('.icon-move');
-  [].forEach.call(draggable, function (el) {
-    var button = el.parentNode;
+  var buttons = document.querySelectorAll('[data-bookmarklet-button]');
+  [].forEach.call(buttons, function (button) {
     button.draggable = true;
     button.ondragstart = function (event) {
       root.className += ' js-show-bookmark-hint';


### PR DESCRIPTION
This fixes the temporary implementation that used the drag icon, and broke when I removed the drag icon. Also now include a guard for IE8 so that it won't raise errors if `document.querySelectorAll` doesn't exist.
