### PR TITLE
Update gulp-sass for compatibility with current versions of Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "gulp-plumber": "^1.0.0",
     "gulp-rename": "^1.2.0",
     "gulp-rev": "^3.0.1",
-    "gulp-sass": "^1.3.3",
+    "gulp-sass": "^2.1.0",
     "gulp-sourcemaps": "^1.5.1",
     "gulp-uglify": "^1.1.0",
     "imagemin-pngcrush": "^4.0.0",


### PR DESCRIPTION
Update gulp-sass to a newer version in order to bring
in a node-sass version which is compatible with current
stable Node releases (v4+)