### PR TITLE
Use posts page for search, if set

### DIFF
--- a/templates/searchform.php
+++ b/templates/searchform.php
@@ -1,4 +1,13 @@
-<form role="search" method="get" class="search-form form-inline" action="<?= esc_url(home_url('/')); ?>">
+<?php
+function hy_search_page_url() {
+  if(get_option('show_on_front') === 'page') {
+    return get_permalink(get_option('page_for_posts'));
+  } else {
+    return home_url('/');
+  }
+}
+?>
+<form role="search" method="get" class="search-form form-inline" action="<?= esc_url(hy_search_page_url()); ?>">
   <label class="sr-only"><?php _e('Search for:', 'sage'); ?></label>
   <div class="input-group">
     <input type="search" value="<?= get_search_query(); ?>" name="s" class="search-field form-control" placeholder="<?php _e('Search', 'sage'); ?> <?php bloginfo('name'); ?>" required>


### PR DESCRIPTION
WordPress allows setting the "posts" page to be a page other than the front page, something we use to host the blog at /blog.

Add a switch in the search form template which detects if this setting is configured, and if so changes the search action to point to the posts page rather than the home page.