### PR TITLE
removing hiring banner

### DIFF
--- a/templates/header.php
+++ b/templates/header.php
@@ -1,11 +1,3 @@
-<!-- Temporary hiring banner -->
-<header class="banner hiring" role="banner">
-  <div class="container">
-    <span>We're <a href="https://hypothes.is/jobs/">hiring!</a></span>
-  </div>
-</header>
-<!-- / Temporary hiring banner -->
-
 <header class="navbar navbar-default navbar-static-top">
   <div class="container">
     <div class="navbar-header">


### PR DESCRIPTION
If it's not a huge hassle before we switch sites, it would be best to remove the hiring banner as the jobs page has already been updated to reflect that H. has no open positions.